### PR TITLE
Allow user to define indexes for row/column/value of the heatmap at setup

### DIFF
--- a/R/setup_heatmap.R
+++ b/R/setup_heatmap.R
@@ -9,6 +9,9 @@
 #' @param        x             A poly_frame or list of named data-frames. This
 #'   must contain a data-frame called body_data which defines the data used in
 #'   the body of the heatmap (by two index columns and a value column).
+#' @param        row_index,column_index,value_index   In the data-frames
+#'   provided, which column contains the data for the rows / columns / body of
+#'   the heatmap?
 #'
 #' @importFrom   magrittr      %>%
 #' @importFrom   tidyr         spread_
@@ -17,18 +20,18 @@
 #'
 #' @export
 
-setup_heatmap <- function(x) {
-  row_index <- "feature_id"
-  col_index <- "sample_id"
-  value_index <- "fitted_value"
-
+setup_heatmap <- function(x,
+                          row_index = "feature_id",
+                          column_index = "sample_id",
+                          value_index = "fitted_value") {
   stopifnot(
     .is_nonempty_list_of_data_frames(x) && "body_data" %in% names(x)
   )
+
   body_matrix <- tidyr::spread_(
     x$body_data,
     value_col = value_index,
-    key_col = col_index
+    key_col = column_index
   ) %>%
     as_matrix(rowname_col = row_index)
 

--- a/man/setup_heatmap.Rd
+++ b/man/setup_heatmap.Rd
@@ -4,12 +4,17 @@
 \alias{setup_heatmap}
 \title{setup_heatmap: defines the data-structures for use in constructing heatmaps}
 \usage{
-setup_heatmap(x)
+setup_heatmap(x, row_index = "feature_id", column_index = "sample_id",
+  value_index = "fitted_value")
 }
 \arguments{
 \item{x}{A poly_frame or list of named data-frames. This
 must contain a data-frame called body_data which defines the data used in
 the body of the heatmap (by two index columns and a value column).}
+
+\item{row_index, column_index, value_index}{In the data-frames
+provided, which column contains the data for the rows / columns / body of
+the heatmap?}
 }
 \description{
 setup_heatmap: defines the data-structures for use in constructing heatmaps

--- a/tests/testthat/test_setup_heatmap.R
+++ b/tests/testthat/test_setup_heatmap.R
@@ -35,6 +35,7 @@ test_that("`setup_heatmap` works for valid input", {
     sample_id = rep(LETTERS[1:3], each = 3),
     fitted_value = 1:9
   )
+
   m1 <- matrix(
     1:9,
     nrow = 3, ncol = 3,
@@ -45,6 +46,36 @@ test_that("`setup_heatmap` works for valid input", {
     setup_heatmap(list(body_data = df1)),
     basic_hmd(m1),
     info = "If only bodydata is provided, it's converted to a matrix"
+  )
+})
+
+###############################################################################
+
+test_that("user can define row, column and value indexes in `setup_heatmap`", {
+  df1 <- data.frame(
+    ensembl_id = letters[1:3],
+    treatment_group = rep(LETTERS[1:3], each = 3),
+    normalised_expression = 1:9
+  )
+
+  m1 <- matrix(
+    1:9,
+    nrow = 3, ncol = 3,
+    dimnames = list(letters[1:3], LETTERS[1:3])
+  )
+
+  expect_equal(
+    object = setup_heatmap(
+      list(body_data = df1),
+      row_index = "ensembl_id",
+      column_index = "treatment_group",
+      value_index = "normalised_expression"
+    ),
+    expected = basic_hmd(m1),
+    info = paste(
+      "[row|column|value]_index should be used to construct body_matrix from",
+      "body_df"
+    )
   )
 })
 


### PR DESCRIPTION
    Added args `row_index`, `column_index`, `value_index` to `setup_heatmap`.
    
    In the `body_data` data-frame that is passed in
    
    - the column for the row-index is represented in the rows ...;
    - the column_index column is represented in the columns ...;
    - the value_index column is represented in the body ...;
    
     of the resulting heatmap.

Added test: user can specify index-names in the body_df when setting up a heatmap
