### PR TITLE
Set plotting formats using format_heatmap()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ URL: https://github.com/russHyde/functionalheatmap
 BugReports: https://github.com/russHyde/functionalheatmap/issues
 RoxygenNote: 6.0.1
 Suggests: testthat,
-    covr
+    covr,
+    mockery
 Collate:
     'classes.R'
     'data_manipulation.R'

--- a/R/format_heatmap.R
+++ b/R/format_heatmap.R
@@ -4,11 +4,12 @@
 
 ###############################################################################
 
-#.get_default_formatting <- function() {
-#  list(
-#    show_row_names = FALSE
-#  )
-#}
+.get_default_formatting <- function() {
+  list(
+    show_row_names = FALSE,
+    cluster_columns = FALSE
+  )
+}
 
 # Default formatting: no rownames, no column clustering
 
@@ -24,15 +25,12 @@ format_heatmap <- function(x) {
   if (!methods::is(x, "heatmap_data")) {
     stop("`x` should be a `heatmap_data` object in `format_heatmap`")
   }
-  formats <- list(
-    show_row_names = FALSE,
-    cluster_columns = FALSE
-  )
-  x
-  append(
-    x,
-    list(formats = formats)
-  )
+
+  formats <- .get_default_formatting()
+
+  x %>%
+    append(list(formats = formats)) %>%
+    as_heatmap_data()
 }
 
 ###############################################################################

--- a/R/format_heatmap.R
+++ b/R/format_heatmap.R
@@ -21,12 +21,18 @@
 #' @importFrom   methods       is
 #' @export
 
-format_heatmap <- function(x) {
+format_heatmap <- function(x, ...) {
   if (!methods::is(x, "heatmap_data")) {
     stop("`x` should be a `heatmap_data` object in `format_heatmap`")
   }
 
-  formats <- .get_default_formatting()
+  formats <- list(...)
+  defaults <- .get_default_formatting()
+
+  formats <- append(
+    formats,
+    defaults[!names(defaults) %in% names(formats)]
+  )
 
   x %>%
     append(list(formats = formats)) %>%

--- a/R/format_heatmap.R
+++ b/R/format_heatmap.R
@@ -17,6 +17,8 @@
 #'
 #' @param        x             A heatmap_data object. As returned by
 #'   `setup_heatmap`.
+#' @param        ...           Any user-specific formatting flags to be passed
+#'   to Heatmap().
 #'
 #' @importFrom   methods       is
 #' @export

--- a/R/format_heatmap.R
+++ b/R/format_heatmap.R
@@ -4,6 +4,14 @@
 
 ###############################################################################
 
+#.get_default_formatting <- function() {
+#  list(
+#    show_row_names = FALSE
+#  )
+#}
+
+# Default formatting: no rownames, no column clustering
+
 #' format_heatmap
 #'
 #' @param        x             A heatmap_data object. As returned by
@@ -16,7 +24,15 @@ format_heatmap <- function(x) {
   if (!methods::is(x, "heatmap_data")) {
     stop("`x` should be a `heatmap_data` object in `format_heatmap`")
   }
+  formats <- list(
+    show_row_names = FALSE,
+    cluster_columns = FALSE
+  )
   x
+  append(
+    x,
+    list(formats = formats)
+  )
 }
 
 ###############################################################################

--- a/R/plot_heatmap.R
+++ b/R/plot_heatmap.R
@@ -18,7 +18,13 @@ plot_heatmap <- function(x) {
   if (missing(x) || !is(x, "heatmap_data")) {
     stop("`x` should be a defined `heatmap_data` object in `plot_heatmap`")
   }
-  ComplexHeatmap::Heatmap(x$body_matrix)
+  do.call(
+    ComplexHeatmap::Heatmap,
+    append(
+      list(x$body_matrix),
+      x$formats
+    )
+  )
 }
 
 ###############################################################################

--- a/man/format_heatmap.Rd
+++ b/man/format_heatmap.Rd
@@ -9,6 +9,9 @@ format_heatmap(x, ...)
 \arguments{
 \item{x}{A heatmap_data object. As returned by
 `setup_heatmap`.}
+
+\item{...}{Any user-specific formatting flags to be passed
+to Heatmap().}
 }
 \description{
 format_heatmap

--- a/man/format_heatmap.Rd
+++ b/man/format_heatmap.Rd
@@ -4,7 +4,7 @@
 \alias{format_heatmap}
 \title{format_heatmap}
 \usage{
-format_heatmap(x)
+format_heatmap(x, ...)
 }
 \arguments{
 \item{x}{A heatmap_data object. As returned by

--- a/tests/testthat/test_format_heatmap.R
+++ b/tests/testthat/test_format_heatmap.R
@@ -40,11 +40,11 @@ test_that("`format_heatmap` works on valid input", {
 test_that("format_heatmap modifies formatting args for ComplexHeatmap", {
   hd1 <- as_heatmap_data(list(body_matrix = matrix()))
 
-  #expect_equal(
-  #  format_heatmap(hd1)$formats,
-  #  list(show_row_names = FALSE, cluster_columns = FALSE),
-  #  info = "format_heatmap defines sensible defaults for omics"
-  #)
+  expect_equivalent(
+    format_heatmap(hd1)$formats,
+    list(cluster_columns = FALSE, show_row_names = FALSE),
+    info = "`format_heatmap` defines sensible defaults for omics"
+  )
 
   #expect_equal(
   #

--- a/tests/testthat/test_format_heatmap.R
+++ b/tests/testthat/test_format_heatmap.R
@@ -46,7 +46,9 @@ test_that("format_heatmap modifies formatting args for ComplexHeatmap", {
     info = "`format_heatmap` defines sensible defaults for omics"
   )
 
-  #expect_equal(
-  #
-  #)
+  expect_equal(
+    format_heatmap(hd1, show_row_names = TRUE, cluster_columns = TRUE)$formats,
+    list(cluster_columns = TRUE, show_row_names = TRUE),
+    info = "`format_heatmap` lets user define formatting flags for Heatmap()"
+  )
 })

--- a/tests/testthat/test_format_heatmap.R
+++ b/tests/testthat/test_format_heatmap.R
@@ -4,7 +4,7 @@ context("Tests for `format_heatmap` in `functionalheatmap`")
 
 ###############################################################################
 
-test_that("`format_heatmap` works on invalid input", {
+test_that("format_heatmap does not work on invalid input", {
   expect_error(
     format_heatmap(),
     info = "no input error to format_heatmap"
@@ -16,9 +16,11 @@ test_that("`format_heatmap` works on invalid input", {
   )
 })
 
+###############################################################################
 
 test_that("`format_heatmap` works on valid input", {
-  hd1 <- as_heatmap_data(list(body_matrix = matrix()))
+  m1 <- matrix(rnorm(12), nrow = 4)
+  hd1 <- as_heatmap_data(list(body_matrix = m1))
 
   expect_is(
     format_heatmap(hd1),
@@ -28,7 +30,23 @@ test_that("`format_heatmap` works on valid input", {
 
   expect_equal(
     format_heatmap(hd1)$body_matrix,
-    matrix(),
-    info = "Data should be unmodified by `format_heatmap`"
+    m1,
+    info = "Data should be unmodified by format_heatmap"
   )
+})
+
+###############################################################################
+
+test_that("format_heatmap modifies formatting args for ComplexHeatmap", {
+  hd1 <- as_heatmap_data(list(body_matrix = matrix()))
+
+  #expect_equal(
+  #  format_heatmap(hd1)$formats,
+  #  list(show_row_names = FALSE, cluster_columns = FALSE),
+  #  info = "format_heatmap defines sensible defaults for omics"
+  #)
+
+  #expect_equal(
+  #
+  #)
 })


### PR DESCRIPTION
Added default formats for heatmap plotting (no row-names, no column clustering)

The formatting arguments were added to a formats entry in the heatmap_data object and passed through to plot_heatmap

Set some tests to check that format entry was updated on user demand and used mockery to check that any plotting arguments that were set by the user were set when Heatmap() was ultimately called.