### PR TITLE
add function `as_body_matrix`

### DIFF
--- a/R/data_manipulation.R
+++ b/R/data_manipulation.R
@@ -1,9 +1,24 @@
 ###############################################################################
 
-#' converts a data-frame into a matrix
+#' Converts a tidy-data-frame into a matrix using specified columns of the
+#' data-frame to index the rows and columns of the resulting matrix
+#'
+#' @importFrom   tidyr         spread_
+#' @noRd
+
+as_body_matrix <- function(df, row_index, column_index, value_index) {
+  tidyr::spread_(
+      df,
+      value_col = value_index,
+      key_col = column_index
+    ) %>%
+    as_matrix(rowname_col = row_index)
+}
+
+#' Converts a data-frame into a matrix
 #'
 #' If the user specifies `rowname_col`, this column is extracted from the
-#' data-frame and used to define the rownames of the matrix
+#' data-frame and used to define the rownames of the matrix.
 #'
 #' @importFrom   dplyr         select_
 #' @importFrom   magrittr      set_rownames   %>%

--- a/R/setup_heatmap.R
+++ b/R/setup_heatmap.R
@@ -28,12 +28,9 @@ setup_heatmap <- function(x,
     .is_nonempty_list_of_data_frames(x) && "body_data" %in% names(x)
   )
 
-  body_matrix <- tidyr::spread_(
-    x$body_data,
-    value_col = value_index,
-    key_col = column_index
-  ) %>%
-    as_matrix(rowname_col = row_index)
+  body_matrix <- as_body_matrix(
+    x$body_data, row_index, column_index, value_index
+  )
 
   as_heatmap_data(
     list(body_matrix = body_matrix)

--- a/tests/testthat/test_data_manipulation.R
+++ b/tests/testthat/test_data_manipulation.R
@@ -31,3 +31,21 @@ test_that("as_matrix", {
 })
 
 ###############################################################################
+
+test_that("as_body_matrix", {
+  tidy_df1 <- data.frame(
+    my_rows = letters[1:3],
+    my_cols = rep(LETTERS[1:4], each = 3),
+    my_vals = 1:12
+  )
+  matrix1 <- matrix(1:12, nrow = 3, dimnames = list(letters[1:3], LETTERS[1:4]))
+
+  expect_equal(
+    object = as_body_matrix(tidy_df1, "my_rows", "my_cols", "my_vals"),
+    expected = matrix1,
+    info = paste(
+      "convert tidy data-frame to a matrix using specified df-columns to",
+      "index the row/cols of the matrix"
+    )
+  )
+})


### PR DESCRIPTION
The function converts a tidy data-frame into a matrix where the rows and
columns are indexed by user-selected columns of the data-frame. The values in
the matrix come from a single specified column of the data-frame.

A single test was added.

`setup_heatmap` was refactored to use `as_body_matrix` to convert the input
`body_data` entry.