### PR TITLE
Add row-data and restrict features

### DIFF
--- a/R/data_manipulation.R
+++ b/R/data_manipulation.R
@@ -8,10 +8,10 @@
 
 as_body_matrix <- function(df, row_index, column_index, value_index) {
   tidyr::spread_(
-      df,
-      value_col = value_index,
-      key_col = column_index
-    ) %>%
+    df,
+    value_col = value_index,
+    key_col = column_index
+  ) %>%
     as_matrix(rowname_col = row_index)
 }
 

--- a/R/setup_heatmap.R
+++ b/R/setup_heatmap.R
@@ -4,6 +4,7 @@
 
 ###############################################################################
 
+
 #' setup_heatmap: defines the data-structures for use in constructing heatmaps
 #'
 #' @param        x             A poly_frame or list of named data-frames. This
@@ -28,22 +29,37 @@ setup_heatmap <- function(x,
     .is_nonempty_list_of_data_frames(x) && "body_data" %in% names(x)
   )
 
+  keep_features <- .get_features_from_heatmap_input(x, row_index)
+
   body_matrix <- as_body_matrix(
-    x$body_data, row_index, column_index, value_index
-  )
+    x$body_data,
+    row_index, column_index, value_index
+  )[keep_features, ]
 
   heatmap_list <- list(body_matrix = body_matrix)
 
   if("row_data" %in% names(x)) {
-    keep_features <- intersect(rownames(body_matrix), x$row_data[[row_index]])
-
-    heatmap_list$row_data <- x$row_data[
-      x$row_data[[row_index]] %in% keep_features,
-    ]
-    heatmap_list$body_matrix <- heatmap_list$body_matrix[keep_features, ]
+    # add the row data to the heatmap-data, ensureing the row-ordering matches
+    # that for the body-data
+    reordering <- match(keep_features, x$row_data[[row_index]])
+    heatmap_list$row_data <- x$row_data[reordering, ]
   }
 
   as_heatmap_data(heatmap_list)
+}
+
+###############################################################################
+
+# helper functions
+
+.get_features_from_heatmap_input <- function(x, row_index) {
+  features <- unique(x$body_data[[row_index]])
+
+  if ("row_data" %in% names(x)) {
+    features <- intersect(features, x$row_data[[row_index]])
+  }
+
+  sort(features)
 }
 
 ###############################################################################

--- a/R/setup_heatmap.R
+++ b/R/setup_heatmap.R
@@ -32,9 +32,18 @@ setup_heatmap <- function(x,
     x$body_data, row_index, column_index, value_index
   )
 
-  as_heatmap_data(
-    list(body_matrix = body_matrix)
-  )
+  heatmap_list <- list(body_matrix = body_matrix)
+
+  if("row_data" %in% names(x)) {
+    keep_features <- intersect(rownames(body_matrix), x$row_data[[row_index]])
+
+    heatmap_list$row_data <- x$row_data[
+      x$row_data[[row_index]] %in% keep_features,
+    ]
+    heatmap_list$body_matrix <- heatmap_list$body_matrix[keep_features, ]
+  }
+
+  as_heatmap_data(heatmap_list)
 }
 
 ###############################################################################

--- a/R/setup_heatmap.R
+++ b/R/setup_heatmap.R
@@ -4,7 +4,6 @@
 
 ###############################################################################
 
-
 #' setup_heatmap: defines the data-structures for use in constructing heatmaps
 #'
 #' @param        x             A poly_frame or list of named data-frames. This
@@ -38,7 +37,7 @@ setup_heatmap <- function(x,
 
   heatmap_list <- list(body_matrix = body_matrix)
 
-  if("row_data" %in% names(x)) {
+  if ("row_data" %in% names(x)) {
     # add the row data to the heatmap-data, ensureing the row-ordering matches
     # that for the body-data
     reordering <- match(keep_features, x$row_data[[row_index]])

--- a/tests/testthat/test_setup_heatmap.R
+++ b/tests/testthat/test_setup_heatmap.R
@@ -95,7 +95,8 @@ test_that("only features common to the body and row-data are heatmapped", {
   )
 
   body1_matrix <- matrix(
-    1:9, nrow = 3, dimnames = list(letters[1:3], LETTERS[1:3])
+    1:9,
+    nrow = 3, dimnames = list(letters[1:3], LETTERS[1:3])
   )
 
   obj1 <- setup_heatmap(list(body_data = body1, row_data = rows1))
@@ -179,7 +180,8 @@ test_that("only features common to the body and row-data are heatmapped", {
   )
 
   body4_matrix <- matrix(
-    1:6, nrow = 2, dimnames = list(letters[2:3], LETTERS[1:3])
+    1:6,
+    nrow = 2, dimnames = list(letters[2:3], LETTERS[1:3])
   )
 
   obj4 <- setup_heatmap(list(body_data = body4, row_data = rows1))
@@ -194,5 +196,4 @@ test_that("only features common to the body and row-data are heatmapped", {
       "be filtered down by `setup_heatmap`"
     )
   )
-
 })

--- a/tests/testthat/test_setup_heatmap.R
+++ b/tests/testthat/test_setup_heatmap.R
@@ -102,7 +102,9 @@ test_that("only features common to the body and row-data are heatmapped", {
 
   expect_equal(
     object = obj1,
-    expected = list(body_matrix = body1_matrix, row_data = rows1),
+    expected = as_heatmap_data(
+      list(body_matrix = body1_matrix, row_data = rows1)
+    ),
     info = paste(
       "body/row-data should be unfiltered if all features are in both",
       "body and row-data"
@@ -130,14 +132,63 @@ test_that("only features common to the body and row-data are heatmapped", {
 
   expect_equal(
     object = obj2,
-    expected = list(body_matrix = body2_matrix, row_data = rows2),
+    expected = as_heatmap_data(
+      list(body_matrix = body2_matrix, row_data = rows2)
+    ),
     info = paste(
       "body/row-data should be unfiltered if all features are in both",
       "body and row-data (regardless of their order in the input)"
     )
   )
 
-  # row_data features are a subset of body_data features
+  # row_data features are a subset of body_data features - body_data should be
+  # filtered
+  rows3 <- data.frame(
+    feature_id = letters[1:2],
+    annotation = c(TRUE, FALSE)
+  )
 
-  # row_data features are a superset of body_data features
+  body3_matrix <- matrix(
+    c(1:2, 4:5, 7:8),
+    nrow = 2, dimnames = list(letters[1:2], LETTERS[1:3])
+  )
+
+  obj3 <- setup_heatmap(list(body_data = body1, row_data = rows3))
+
+  expect_equal(
+    object = obj3,
+    expected = as_heatmap_data(
+      list(body_matrix = body3_matrix, row_data = rows3)
+    ),
+    info = paste(
+      "row-data has a subset of the body-data features: so body-data should",
+      "be filtered down by `setup_heatmap`"
+    )
+  )
+
+  # row_data features are a superset of body_data features - row_data should be
+  # filtered
+  body4 <- data.frame(
+    feature_id = letters[2:3],
+    sample_id = rep(LETTERS[1:3], each = 2),
+    fitted_value = 1:6
+  )
+
+  body4_matrix <- matrix(
+    1:6, nrow = 2, dimnames = list(letters[2:3], LETTERS[1:3])
+  )
+
+  obj4 <- setup_heatmap(list(body_data = body4, row_data = rows1))
+
+  expect_equal(
+    object = obj4,
+    expected = as_heatmap_data(
+      list(body_matrix = body4_matrix, row_data = rows1[-1, ])
+    ),
+    info = paste(
+      "row-data has a superset of the body-data features: so row-data should",
+      "be filtered down by `setup_heatmap`"
+    )
+  )
+
 })

--- a/tests/testthat/test_setup_heatmap.R
+++ b/tests/testthat/test_setup_heatmap.R
@@ -133,11 +133,15 @@ test_that("only features common to the body and row-data are heatmapped", {
   expect_equal(
     object = obj2,
     expected = as_heatmap_data(
-      list(body_matrix = body2_matrix, row_data = rows2)
+      list(
+        body_matrix = body2_matrix,
+        row_data = rows2[order(rows2$feature_id), ]
+      )
     ),
     info = paste(
       "body/row-data should be unfiltered if all features are in both",
-      "body and row-data (regardless of their order in the input)"
+      "body and row-data (regardless of their order in the input)",
+      "and the `feature_id`s should be in identical order."
     )
   )
 

--- a/tests/testthat/test_setup_heatmap.R
+++ b/tests/testthat/test_setup_heatmap.R
@@ -80,3 +80,64 @@ test_that("user can define row, column and value indexes in `setup_heatmap`", {
 })
 
 ###############################################################################
+
+test_that("only features common to the body and row-data are heatmapped", {
+  # row_data features and body_data features are identical and order-matched
+  body1 <- data.frame(
+    feature_id = letters[1:3],
+    sample_id = rep(LETTERS[1:3], each = 3),
+    fitted_value = 1:9
+  )
+
+  rows1 <- data.frame(
+    feature_id = letters[1:3],
+    annotation = c(TRUE, FALSE, TRUE)
+  )
+
+  body1_matrix <- matrix(
+    1:9, nrow = 3, dimnames = list(letters[1:3], LETTERS[1:3])
+  )
+
+  obj1 <- setup_heatmap(list(body_data = body1, row_data = rows1))
+
+  expect_equal(
+    object = obj1,
+    expected = list(body_matrix = body1_matrix, row_data = rows1),
+    info = paste(
+      "body/row-data should be unfiltered if all features are in both",
+      "body and row-data"
+    )
+  )
+
+  # row_data features and body_data features are identical but disordered
+  body2 <- data.frame(
+    feature_id = letters[3:1],
+    sample_id = rep(LETTERS[1:3], each = 3),
+    fitted_value = 1:9
+  )
+
+  rows2 <- data.frame(
+    feature_id = c("b", "a", "c"),
+    annotation = c(TRUE, FALSE, TRUE)
+  )
+
+  body2_matrix <- matrix(
+    c(3, 2, 1, 6, 5, 4, 9, 8, 7),
+    nrow = 3, dimnames = list(letters[1:3], LETTERS[1:3])
+  )
+
+  obj2 <- setup_heatmap(list(body_data = body2, row_data = rows2))
+
+  expect_equal(
+    object = obj2,
+    expected = list(body_matrix = body2_matrix, row_data = rows2),
+    info = paste(
+      "body/row-data should be unfiltered if all features are in both",
+      "body and row-data (regardless of their order in the input)"
+    )
+  )
+
+  # row_data features are a subset of body_data features
+
+  # row_data features are a superset of body_data features
+})


### PR DESCRIPTION
On passing in a body-data and a row-data data-frame, setup_heatmap restricts the two data-frames to contain the same `feature_id`s (the intersection of the two sets) and ensures the body_matrix and row_data-frame that are returned have commensurate rows (feature_id in row X of body_matrix matches that in row X of row_data)