### PR TITLE
fixes #14: add clusters/splits in format_heatmap

### DIFF
--- a/R/format_heatmap.R
+++ b/R/format_heatmap.R
@@ -4,13 +4,6 @@
 
 ###############################################################################
 
-.get_default_formatting <- function() {
-  list(
-    show_row_names = FALSE,
-    cluster_columns = FALSE
-  )
-}
-
 # Default formatting: no rownames, no column clustering
 
 #' format_heatmap
@@ -18,7 +11,9 @@
 #' @param        x             A heatmap_data object. As returned by
 #'   `setup_heatmap`.
 #' @param        ...           Any user-specific formatting flags to be passed
-#'   to Heatmap().
+#'   to Heatmap(). An exception is `split`: if this flag is set it should
+#'   define a vector of column-names from the `row_data` part of `x`, these
+#'   columns are then extracted and passed to Heatmap().
 #'
 #' @importFrom   methods       is
 #' @export
@@ -28,17 +23,50 @@ format_heatmap <- function(x, ...) {
     stop("`x` should be a `heatmap_data` object in `format_heatmap`")
   }
 
-  formats <- list(...)
-  defaults <- .get_default_formatting()
+  dots <- list(...)
 
-  formats <- append(
-    formats,
-    defaults[!names(defaults) %in% names(formats)]
-  )
+  formats <- .get_default_formatting() %>%
+    .append_format_args(dots) %>%
+    .append_split_args_if_defined(x, dots$split)
 
   x %>%
     append(list(formats = formats)) %>%
     as_heatmap_data()
 }
+
+###############################################################################
+
+.get_default_formatting <- function() {
+  list(
+    show_row_names = FALSE,
+    cluster_columns = FALSE
+  )
+}
+
+###############################################################################
+
+.append_format_args <- function(current_args, new_args) {
+  non_updated_args <- setdiff(names(current_args), names(new_args))
+  append(new_args, current_args[non_updated_args])
+}
+
+.get_split_from_row_data <- function(x, split_columns) {
+  stopifnot("row_data" %in% names(x))
+  row_data <- x$row_data
+  row_data[split_columns]
+}
+
+.append_split_args_if_defined <- function(current_args,
+                                          heatmap_data,
+                                          split_columns = NULL) {
+  if (is.null(split_columns)) {
+    return(current_args)
+  }
+  .append_format_args(
+    current_args,
+    list(split = .get_split_from_row_data(heatmap_data, split_columns))
+  )
+}
+
 
 ###############################################################################

--- a/man/format_heatmap.Rd
+++ b/man/format_heatmap.Rd
@@ -11,7 +11,9 @@ format_heatmap(x, ...)
 `setup_heatmap`.}
 
 \item{...}{Any user-specific formatting flags to be passed
-to Heatmap().}
+to Heatmap(). An exception is `split`: if this flag is set it should
+define a vector of column-names from the `row_data` part of `x`, these
+columns are then extracted and passed to Heatmap().}
 }
 \description{
 format_heatmap

--- a/tests/testthat/test_format_heatmap.R
+++ b/tests/testthat/test_format_heatmap.R
@@ -93,3 +93,34 @@ test_that("args set by format_heatmap pass through to a Heatmap() call", {
     )
   )
 })
+
+###############################################################################
+
+test_that("`split` can be defined using columns of `row_data`", {
+  hd1 <- as_heatmap_data(
+    list(
+      body_matrix = matrix(
+        1:12,
+        nrow = 4, dimnames = list(letters[1:4], LETTERS[1:3])
+      ),
+      row_data = data.frame(
+        feature_id = letters[1:4], my_split = rep(1:2, each = 2)
+      )
+    )
+  )
+
+  expect_equal(
+    object = format_heatmap(hd1, split = "my_split")$formats$split,
+    expected = data.frame(
+      my_split = rep(1:2, each = 2)
+    ),
+    info = "`split` defined by a single column of `row_data`"
+  )
+
+  expect_error(
+    object = format_heatmap(hd1, split = "not a column"),
+    info = "`split` columns should be present in the `row_data` data-frame"
+  )
+})
+
+###############################################################################


### PR DESCRIPTION
Pre-existing clustering of the features in a heatmap can be passed through by
setting split = c(colname1, colname2, ...) in `format_heatmap`. Here, the
colnames must be present in the row_data entry of the heatmap_data object.

That the `split` argument isn't passed directly through to Heatmap is annotated
in the docs for `format_heatmap()`.

Tests:

- single column that is present within `row_data`

- single column that is absent from `row_data` throws an error