### PR TITLE
ensure user can format any row-annotations

### DIFF
--- a/R/annotate_heatmap.R
+++ b/R/annotate_heatmap.R
@@ -11,20 +11,34 @@
 #' @param        row_annotations   Which columns of the `row_data` entry in `x`
 #'   should be used when plotting annotations alongside the rows of the
 #'   heatmap?
+#' @param        row_dots      Additional arguments to be passed to
+#'   HeatmapAnnotation for the row-annotations. For example, `show_legend`,
+#'   `col`. Check the docs for HeatmapAnnotation for parameter names.
 #'
+#' @importFrom   magrittr      %>%
 #' @importFrom   methods       is
 #' @export
 
 annotate_heatmap <- function(x,
-                             row_annotations = NULL) {
+                             row_annotations = NULL,
+                             row_dots = NULL) {
   if (!methods::is(x, "heatmap_data")) {
     stop("`x` should be a `heatmap_data` object in `annotate_heatmap`")
   }
 
-  .append_row_annotations(x, row_annotations)
+  x %>%
+    .append_row_annotations(row_annotations) %>%
+    .append_row_dots(row_dots)
 }
 
 ###############################################################################
+
+.append_row_dots <- function(x, row_dots = NULL) {
+  if (!is.null(row_dots)) {
+    x$row_dots <- row_dots
+  }
+  x
+}
 
 .append_row_annotations <- function(x, row_annotations = NULL) {
   if (!is.null(row_annotations)) {

--- a/R/plot_heatmap.R
+++ b/R/plot_heatmap.R
@@ -27,9 +27,12 @@ plot_heatmap <- function(x) {
   )
 
   if ("row_annotations" %in% names(x)) {
-    ra <- ComplexHeatmap::HeatmapAnnotation(
-      x$row_annotations,
-      which = "row"
+    ra <- do.call(
+      ComplexHeatmap::HeatmapAnnotation,
+      append(
+        list(df = x$row_annotations, which = "row"),
+        x$row_dots
+      )
     )
     heatmap <- ComplexHeatmap::add_heatmap(heatmap, ra)
   }

--- a/man/annotate_heatmap.Rd
+++ b/man/annotate_heatmap.Rd
@@ -5,7 +5,7 @@
 \title{Add row annotations to a heatmap based on columns from the `row_data` entry
 of a `heatmap_data` object}
 \usage{
-annotate_heatmap(x, row_annotations = NULL)
+annotate_heatmap(x, row_annotations = NULL, row_dots = NULL)
 }
 \arguments{
 \item{x}{A heatmap_data object.}
@@ -13,6 +13,10 @@ annotate_heatmap(x, row_annotations = NULL)
 \item{row_annotations}{Which columns of the `row_data` entry in `x`
 should be used when plotting annotations alongside the rows of the
 heatmap?}
+
+\item{row_dots}{Additional arguments to be passed to
+HeatmapAnnotation for the row-annotations. For example, `show_legend`,
+`col`.}
 }
 \description{
 Add row annotations to a heatmap based on columns from the `row_data` entry

--- a/tests/testthat/test_annotate_heatmap.R
+++ b/tests/testthat/test_annotate_heatmap.R
@@ -66,8 +66,48 @@ test_that("row_annotation data-frame can be appended to heatmap_data", {
 ###############################################################################
 
 test_that(
-  "row_annotations are added to a plotted heatmap if they are defined", {
-    # pass-through
-    # - how to test this?
+  paste(
+    "if defined, row_annotations and contents of row_dots are added to a",
+    "plotted heatmap"
+  ), {
+    hd1 <- as_heatmap_data(list(
+      body_matrix = matrix(1:12, nrow = 4),
+      row_data = data.frame(
+        foo = c(FALSE, TRUE),
+        bar = 1:4
+      )
+    ))
+
+    m <- mockery::mock(1)
+    testthat::with_mock(
+      HeatmapAnnotation = m, {
+        plot_heatmap(
+          annotate_heatmap(
+            hd1,
+            row_annotations = "foo", row_dots = list(na_col = "red")
+          )
+        )
+      },
+      .env = "ComplexHeatmap"
+    )
+    annotation_args <- mockery::mock_args(m)[[1]]
+
+    expect_equal(
+      annotation_args[[1]],
+      hd1$row_data[, "foo", drop = FALSE],
+      info = paste(
+        "data-frame corresponsing to the cols in the `annotate_heatmap`",
+        "`row_annotations` column(s) is passed to HeatmapAnnotation"
+      )
+    )
+    expect_true(
+      "na_col" %in% names(annotation_args) && annotation_args$na_col == "red",
+      info = paste(
+        "additional args for formatting row-annotations in a heatmap",
+        "(row_dots) are passed through to HeatmapAnnotation()"
+      )
+    )
   }
 )
+
+###############################################################################


### PR DESCRIPTION
Argument `row_dots` to `annotate_heatmap` should be a list. All entries in this
list are ultimately added to the arguments in a `HeatmapAnnotation()` call that
defines how the row-annotations are formatted. This allows the user to specify
any argument (other than `df`) that they would pass into `HeatmapAnnotation()`
when using the package `ComplexHeatmap`.

new function: `.add_row_dots` that adds any annotation-formatting arguments to
the `heatmap_data` object.

test: user can select annotation columns from `row_data` and the annotations
and formats are passed through to `HeatmapAnnotation`.