### PR TITLE
fixes #15: allow >1 pass through `format_heatmap`

### DIFF
--- a/R/format_heatmap.R
+++ b/R/format_heatmap.R
@@ -11,9 +11,9 @@
 #' @param        x             A heatmap_data object. As returned by
 #'   `setup_heatmap`.
 #' @param        ...           Any user-specific formatting flags to be passed
-#'   to Heatmap(). An exception is `split`: if this flag is set it should
+#'   to `Heatmap()`. An exception is `split`: if this flag is set it should
 #'   define a vector of column-names from the `row_data` part of `x`, these
-#'   columns are then extracted and passed to Heatmap().
+#'   columns are then extracted and passed to `Heatmap()`.
 #'
 #' @importFrom   methods       is
 #' @export
@@ -25,12 +25,20 @@ format_heatmap <- function(x, ...) {
 
   dots <- list(...)
 
-  formats <- .get_default_formatting() %>%
-    .append_format_args(dots) %>%
+  initial_formats <- if ("formats" %in% names(x)) {
+    x$formats
+  } else {
+    .get_default_formatting()
+  }
+
+  formats <- initial_formats %>%
+    .append_or_update(dots) %>%
     .append_split_args_if_defined(x, dots$split)
 
   x %>%
-    append(list(formats = formats)) %>%
+    .append_or_update(
+      list(formats = formats)
+    ) %>%
     as_heatmap_data()
 }
 
@@ -45,9 +53,9 @@ format_heatmap <- function(x, ...) {
 
 ###############################################################################
 
-.append_format_args <- function(current_args, new_args) {
-  non_updated_args <- setdiff(names(current_args), names(new_args))
-  append(new_args, current_args[non_updated_args])
+.append_or_update <- function(current_list, new_list) {
+  non_updated_args <- setdiff(names(current_list), names(new_list))
+  append(new_list, current_list[non_updated_args])
 }
 
 .get_split_from_row_data <- function(x, split_columns) {
@@ -62,7 +70,7 @@ format_heatmap <- function(x, ...) {
   if (is.null(split_columns)) {
     return(current_args)
   }
-  .append_format_args(
+  .append_or_update(
     current_args,
     list(split = .get_split_from_row_data(heatmap_data, split_columns))
   )

--- a/tests/testthat/test_format_heatmap.R
+++ b/tests/testthat/test_format_heatmap.R
@@ -96,8 +96,8 @@ test_that("args set by format_heatmap pass through to a Heatmap() call", {
 
 ###############################################################################
 
-test_that("`split` can be defined using columns of `row_data`", {
-  hd1 <- as_heatmap_data(
+.setup_4x3_heatmap_data <- function() {
+  as_heatmap_data(
     list(
       body_matrix = matrix(
         1:12,
@@ -108,6 +108,12 @@ test_that("`split` can be defined using columns of `row_data`", {
       )
     )
   )
+}
+
+###############################################################################
+
+test_that("`split` can be defined using columns of `row_data`", {
+  hd1 <- .setup_4x3_heatmap_data()
 
   expect_equal(
     object = format_heatmap(hd1, split = "my_split")$formats$split,
@@ -120,6 +126,35 @@ test_that("`split` can be defined using columns of `row_data`", {
   expect_error(
     object = format_heatmap(hd1, split = "not a column"),
     info = "`split` columns should be present in the `row_data` data-frame"
+  )
+})
+
+###############################################################################
+
+test_that("format_heatmap can be used multiple times in one pipeline", {
+  hd1 <- .setup_4x3_heatmap_data()
+
+  f1 <- format_heatmap(hd1, na_col = "black", row_title = "my-rows")
+
+  f2 <- format_heatmap(f1, na_col = "purple", column_title = "my_columns")
+
+  expect_true(
+    object = (
+      !"column_title" %in% names(f1$formats) &&
+        f2$formats$column_title == "my_columns"
+    ),
+    info = "adding a new formatting flag in a second format_heatmap call"
+  )
+
+  expect_equal(
+    object = f2$formats$row_title,
+    expected = f2$formats$row_title,
+    info = "format_heatmap should not overwrite unstated formatting flags"
+  )
+
+  expect_true(
+    object = f1$formats$na_col != f2$formats$na_col,
+    info = "format_heatmap can overwrite a named formatting flag"
   )
 })
 


### PR DESCRIPTION
When format_heatmap() is called on a heatmap_data object, H, that already has
some formatting-data stored, any formatting flags in the `format_heatmap` call
are updated in H's formatting-data. Any new formatting flags are appended to
H's formatting data.