### PR TITLE
fixes #29: column-data can be provided as a tibble

### DIFF
--- a/R/annotate_heatmap.R
+++ b/R/annotate_heatmap.R
@@ -57,7 +57,10 @@ annotate_heatmap <- function(x,
       annotation_df_name %in% names(x) &&
         is.data.frame(x[[annotation_df_name]])
     )
-    x[[output_df_name]] <- x[[annotation_df_name]][annotation_track_names]
+    x[[output_df_name]] <- as.data.frame(
+      x[[annotation_df_name]][annotation_track_names],
+      stringsAsFactors = FALSE
+    )
   }
   x
 }

--- a/tests/testthat/test_annotate_heatmap.R
+++ b/tests/testthat/test_annotate_heatmap.R
@@ -88,6 +88,14 @@ test_that("top_annotation data-frame can be appended to heatmap_data", {
   hmd_no_column_data <- as_heatmap_data(
     get_hmd1()[c("body_matrix", "row_data")]
   )
+  hmd_with_tibble_coldata <- as_heatmap_data(
+    append(
+      get_hmd1()[c("body_matrix", "row_data")],
+      list(
+        column_data = tibble::as_tibble(get_hmd1()$column_data)
+      )
+    )
+  )
 
   expect_is(
     annotate_heatmap(hmd1, top_annotations = "zig"),
@@ -121,6 +129,14 @@ test_that("top_annotation data-frame can be appended to heatmap_data", {
       "the top_annotation data should equal the corresponding",
       "sub-data-frame of column_data"
     )
+  )
+
+  expect_equal(
+    object = annotate_heatmap(
+      hmd_with_tibble_coldata, top_annotations = "zig"
+      )$top_annotation,
+    expected = get_hmd1()[["column_data"]]["zig"],
+    info = "top_annotations can be added from a tibble"
   )
 })
 

--- a/tests/testthat/test_annotate_heatmap.R
+++ b/tests/testthat/test_annotate_heatmap.R
@@ -18,7 +18,13 @@ test_that("`annotate_heatmap` fails with invalid input", {
 
 ###############################################################################
 
-get_hmd1 <- function() {
+get_hmd1 <- function(tibble_column_data = FALSE) {
+  df_func <- if (tibble_column_data) {
+    tibble::tibble
+  } else {
+    data.frame
+  }
+
   as_heatmap_data(
     list(
       body_matrix = matrix(
@@ -30,7 +36,7 @@ get_hmd1 <- function() {
         foo = c(TRUE, FALSE, FALSE, TRUE),
         bar = 1:4
       ),
-      column_data = data.frame(
+      column_data = df_func(
         sample_id = LETTERS[1:3],
         zig = c(TRUE, FALSE, FALSE),
         zag = c(20, 10, 50)
@@ -196,10 +202,27 @@ test_that(
       top_dots = list(show_legend = FALSE)
     )
 
+    annotated_hmd_from_tibble_column_data <- get_hmd1(
+      tibble_column_data = TRUE
+    ) %>%
+    annotate_heatmap(
+      top_annotations = "zig"
+    )
+
     expect_is(
       .get_top_annotation_object(hmd_with_zig),
-      "HeatmapAnnotation"
+      "HeatmapAnnotation",
+      "A HeatmapAnnoation can be built from a heatmap_data"
     )
+
+    expect_is(
+      .get_top_annotation_object(annotated_hmd_from_tibble_column_data),
+      "HeatmapAnnotation",
+      info = paste(
+        "A HeatmapAnnotation can be built when tibble column data is provided"
+      )
+    )
+
     expect_is(
       plot_heatmap(hmd_with_zig),
       "Heatmap",

--- a/tests/testthat/test_annotate_heatmap.R
+++ b/tests/testthat/test_annotate_heatmap.R
@@ -202,25 +202,10 @@ test_that(
       top_dots = list(show_legend = FALSE)
     )
 
-    annotated_hmd_from_tibble_column_data <- get_hmd1(
-      tibble_column_data = TRUE
-    ) %>%
-    annotate_heatmap(
-      top_annotations = "zig"
-    )
-
     expect_is(
       .get_top_annotation_object(hmd_with_zig),
       "HeatmapAnnotation",
       "A HeatmapAnnoation can be built from a heatmap_data"
-    )
-
-    expect_is(
-      .get_top_annotation_object(annotated_hmd_from_tibble_column_data),
-      "HeatmapAnnotation",
-      info = paste(
-        "A HeatmapAnnotation can be built when tibble column data is provided"
-      )
     )
 
     expect_is(
@@ -259,3 +244,52 @@ test_that(
     )
   }
 )
+
+###############################################################################
+
+test_that(
+  paste(
+    "Valid objects / plots can be made when tibble annotation data is
+    provided"
+  ),
+  {
+    annotated_hmd_from_tibble_column_data <- get_hmd1(
+      tibble_column_data = TRUE
+    ) %>%
+    annotate_heatmap(
+      top_annotations = "zig"
+    )
+
+    expect_is(
+      .get_top_annotation_object(annotated_hmd_from_tibble_column_data),
+      "HeatmapAnnotation",
+      info = paste(
+        "A HeatmapAnnotation can be built when tibble column data is provided"
+      )
+    )
+
+    expect_is(
+      plot_heatmap(annotated_hmd_from_tibble_column_data),
+      "Heatmap",
+      info = paste(
+        "A Heatmap can be built when tibble `column_data` is provided"
+      )
+    )
+
+    # The following  has to be ran in an interactive session since it uses the
+    # graphics device.
+
+    # A heatmap can be plotted even when annotations have been taken from a
+    #  tibble (as column-data)
+    # - there was originally a bug with 'tibble' use
+    # - TODO: work out how to replace this test with a mocked-out graphics
+    # device since the test (originally) failed after plotting had started
+    skip_if_not(interactive())
+
+    expect_silent(
+      ComplexHeatmap::draw(
+        plot_heatmap(annotated_hmd_from_tibble_column_data)
+      )
+    )
+    dev.off()
+})

--- a/tests/testthat/test_annotate_heatmap.R
+++ b/tests/testthat/test_annotate_heatmap.R
@@ -139,8 +139,9 @@ test_that("top_annotation data-frame can be appended to heatmap_data", {
 
   expect_equal(
     object = annotate_heatmap(
-      hmd_with_tibble_coldata, top_annotations = "zig"
-      )$top_annotation,
+      hmd_with_tibble_coldata,
+      top_annotations = "zig"
+    )$top_annotation,
     expected = get_hmd1()[["column_data"]]["zig"],
     info = "top_annotations can be added from a tibble"
   )
@@ -251,14 +252,13 @@ test_that(
   paste(
     "Valid objects / plots can be made when tibble annotation data is
     provided"
-  ),
-  {
+  ), {
     annotated_hmd_from_tibble_column_data <- get_hmd1(
       tibble_column_data = TRUE
     ) %>%
-    annotate_heatmap(
-      top_annotations = "zig"
-    )
+      annotate_heatmap(
+        top_annotations = "zig"
+      )
 
     expect_is(
       .get_top_annotation_object(annotated_hmd_from_tibble_column_data),
@@ -292,4 +292,5 @@ test_that(
       )
     )
     dev.off()
-})
+  }
+)


### PR DESCRIPTION
top_annotations can now be added to a `heatmap_data` object from a `tibble`

Tests:
- HeatmapAnnotation can be constructed
- top_annotation data.frame is added to heatmap_data
- plotting of a Heatmap that contains a tibble-derived HeatmapAnnotation occurs without error

The last test (that plotting occurs without error) has been restricted - it only runs in an interactive session (so it shouldn't kill the travis-ci builds). But this was the only step where tibbles caused a problem - there seems to be an error in the draw() function and none of my earlier tests covered this.

I would prefer to plot to a temp-file or to /dev/null or have a way of mocking the graphics device